### PR TITLE
[msh] Print all tags in $Entities that surfaces belong to

### DIFF
--- a/src/neut/neut_mesh/neut_mesh_fprintf/neut_mesh_fprintf_msh/neut_mesh_fprintf_msh3.c
+++ b/src/neut/neut_mesh/neut_mesh_fprintf/neut_mesh_fprintf_msh/neut_mesh_fprintf_msh3.c
@@ -9,7 +9,7 @@ neut_mesh_fprintf_msh_entities_dim (FILE * file, char *mode, struct TESS Tess,
                                      struct NODES Nodes, struct MESH Mesh)
 {
   int i, j, k, l;
-  int ElsetId, DomFaceNb, InDomFace = 0;
+  int ElsetId, DomFaceNb, InDomFace;
   double **bbox = ut_alloc_2d (3, 2);
   (void) mode;
 


### PR DESCRIPTION
Refers to Issue #791 

For surfaces, instead of printing "1" as the number of physical tags the surface entity belongs to, loop through the values available in the tesselation data (Tess.DomTessFaceNb) for coincidences with the current entity ID.
    
If this ID is found in the tesselation data, the surface is part of the domain boundary, and so two physical tags should be printed: the ID itself and the tag of the domain face.