### PR TITLE
Make SVG ouptut of `neper -T` show actual result on screen

### DIFF
--- a/src/neut/neut_tess/neut_tess_fprintf/neut_tess_fprintf1.c
+++ b/src/neut/neut_tess/neut_tess_fprintf/neut_tess_fprintf1.c
@@ -452,7 +452,7 @@ neut_tess_fprintf_svg (FILE * file, char *format, struct TESS Tess)
 
   for (i = 1; i <= Tess.FaceQty; i++)
   {
-    fprintf (file,"  <path stroke=\"none\" fill=\"#FFFFFF\" d=\"M ");
+    fprintf (file,"  <path stroke=\"black\" fill=\"#FFFFFF\" d=\"M ");
 
     for (j = 1; j <= Tess.FaceVerQty[i]; j++)
       fprintf (file, " %f,%f %s", Tess.VerCoo[Tess.FaceVerNb[i][j]][0], Tess.VerCoo[Tess.FaceVerNb[i][j]][1],

--- a/src/neut/neut_tess/neut_tess_fprintf/neut_tess_fprintf1.c
+++ b/src/neut/neut_tess/neut_tess_fprintf/neut_tess_fprintf1.c
@@ -430,6 +430,7 @@ neut_tess_fprintf_svg (FILE * file, char *format, struct TESS Tess)
   double **bbox = ut_alloc_2d (3, 2);
   char **vars = NULL, **vals = NULL;
   int varqty;
+  double horizontl_margin, vertical_margin;
 
   ut_string_function (format, NULL, &vars, &vals, &varqty);
   ut_string_string ("", &unit);
@@ -444,11 +445,16 @@ neut_tess_fprintf_svg (FILE * file, char *format, struct TESS Tess)
 
   neut_tess_bboxsize (Tess, bboxsize);
 
+  horizontl_margin = (bbox[0][1] - bbox[0][0]) / 20;
+  vertical_margin  = (bbox[1][1] - bbox[1][0]) / 20;
+
   fprintf (file, "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n");
   fprintf (file, "<!DOCTYPE svg PUBLIC \"-//W3C//DTD SVG 1.1//EN\" \"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd\">\n");
   fprintf (file, "<!-- Generator: Neper (https://neper.info) -->\n");
   fprintf (file, "<svg width=\"%f%s\" height=\"%f%s\" viewBox=\"%f %f %f %f\" version=\"1.1\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:inkscape=\"http://www.inkscape.org/namespaces/inkscape\">\n",
-                 bboxsize[0], unit, bboxsize[1], unit, bbox[0][0], bbox[1][0], bbox[0][1], bbox[1][1]);
+                 bboxsize[0], unit, bboxsize[1], unit,
+                 bbox[0][0] - horizontl_margin, bbox[1][0] - vertical_margin,
+                 bbox[0][1] + horizontl_margin * 1.1, bbox[1][1] + vertical_margin * 1.1);
 
   for (i = 1; i <= Tess.FaceQty; i++)
   {


### PR DESCRIPTION
This pull request consists of two commits editing the file `src/neut/neut_tess/neut_tess_fprintf/neut_tess_fprintf1.c`.
1. The first one changes `stroke=\"none\"` to `stroke=\"black\"` since with `stroke=\"none\"` no lines are shown on screen.
2. The second one adds some margins (5-5.5%) to `viewBox` so that no strokes have been clipped.

An instructional example is `neper -T -n 10 -domain "square(400,300)" -dim 2 -format svg`:
1. in the current state the output is a white screen;
2. after the first change a tesselation with black edges is shown on screen;
3. after the second change a small frame is created around the tesselation and no clipping occurs.

Note that the situation is still not good for small regions.
For instance, running `neper -T -n 10 -dim 2 -format svg` tesselates a square of size $1{\rm px} \times 1{\rm px}$ that can barely be seen.
Furthermore, because the size of the strokes is bigger than 1 pixel, the result is a filled black square.
So, for a better output, some scaling will be necessary, like the visualisation module does for PNG output.