### PR TITLE
Create a GitHub Actions setup: build documentation, executables on Linux and MacOS

### DIFF
--- a/.github/scripts/check-pages-enabled.sh
+++ b/.github/scripts/check-pages-enabled.sh
@@ -1,0 +1,13 @@
+echo "Checking for existence of environment: 'github-pages'"
+
+HTTP_STATUS=$(curl --write-out "%{http_code}" --silent --output /dev/null \
+  --header "Accept: application/vnd.github.v3+json" \
+  "https://api.github.com/repos/$GITHUB_REPOSITORY/environments/github-pages")
+
+if [[ "$HTTP_STATUS" -eq 200 ]]; then
+  echo "Environment 'github-pages' found."
+  echo "enabled=true" >> "$GITHUB_OUTPUT"
+else
+  echo "Environment 'github-pages' does not exist (HTTP status: $HTTP_STATUS)."
+  echo "enabled=false" >> "$GITHUB_OUTPUT"
+fi

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -1,0 +1,50 @@
+name: Build Neper executable on Linux for arm64 and x86_64
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    name: Build Neper executable on Linux
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04-arm
+            arch: arm64
+          - os: ubuntu-24.04
+            arch: x86_64
+
+    steps:
+      - name: Update apt-get
+        run: sudo apt-get update
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install GNU Scientific Library
+        run: sudo apt-get install libgsl-dev
+
+      - name: Create build directory
+        run: mkdir -p src/build
+
+      - name: Generate Makefile
+        working-directory: src/build
+        run: cmake ..
+
+      - name: Build Neper executable
+        working-directory: src/build
+        run: make
+
+      - name: Run tests
+        continue-on-error: true
+        working-directory: src/build
+        run: ctest
+
+      - name: Upload Neper executable
+        uses: actions/upload-artifact@v6
+        with:
+          name: neper-linux-${{ matrix.arch }}
+          path: src/build/neper
+          retention-days: ${{ github.event.repository.private && 1 || 7 }}

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -1,0 +1,62 @@
+name: Build Neper executable on MacOS for arm64 and x86_64
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    name: Build Neper executable on MacOS
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-15
+            arch: arm64
+          - os: macos-15-intel
+            arch: x86_64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install GNU Scientific Library
+        run: brew install gsl
+
+      - name: Install OpenMP
+        run: brew install libomp
+
+      - name: Create build directory
+        run: mkdir -p src/build
+
+      - name: Generate Makefile
+        working-directory: src/build
+        env:
+          MACOSX_DEPLOYMENT_TARGET: 10.15
+        run: |
+          export LDFLAGS="-L$(brew --prefix libomp)/lib"
+          cmake \
+            -DCMAKE_C_COMPILER=$(brew --prefix llvm@18)/bin/clang \
+            -DCMAKE_CXX_COMPILER=$(brew --prefix llvm@18)/bin/clang++ \
+            -DOpenMP_C_FLAGS="-fopenmp -I$(brew --prefix libomp)/include" \
+            -DOpenMP_CXX_FLAGS="-fopenmp -I$(brew --prefix libomp)/include" \
+            -DOpenMP_C_LIB_NAMES="omp" \
+            -DOpenMP_CXX_LIB_NAMES="omp" \
+            -DOpenMP_omp_LIBRARY=$(brew --prefix libomp)/lib/libomp.dylib \
+            ..
+
+      - name: Build Neper executable
+        working-directory: src/build
+        run: make
+
+      - name: Run tests
+        continue-on-error: true
+        working-directory: src/build
+        run: ctest
+
+      - name: Upload Neper executable
+        uses: actions/upload-artifact@v6
+        with:
+          name: neper-macos-${{ matrix.arch }}
+          path: src/build/neper
+          retention-days: ${{ github.event.repository.private && 1 || 7 }}

--- a/.github/workflows/runner.yaml
+++ b/.github/workflows/runner.yaml
@@ -17,3 +17,7 @@ jobs:
   linux:
     name: Linux
     uses: ./.github/workflows/linux.yaml
+
+  macos:
+    name: MacOS
+    uses: ./.github/workflows/macos.yaml

--- a/.github/workflows/runner.yaml
+++ b/.github/workflows/runner.yaml
@@ -13,3 +13,7 @@ jobs:
   website:
     name: Website
     uses: ./.github/workflows/website.yaml
+
+  linux:
+    name: Linux
+    uses: ./.github/workflows/linux.yaml

--- a/.github/workflows/runner.yaml
+++ b/.github/workflows/runner.yaml
@@ -1,0 +1,15 @@
+name: Run all jobs
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  website:
+    name: Website
+    uses: ./.github/workflows/website.yaml

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -1,0 +1,77 @@
+name: Build HTML documentation and deploy the website to GitHub Pages
+
+on:
+  workflow_call:
+
+jobs:
+  build-website:
+    name: Build website with Sphinx using a theme provided by Read the Docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update apt-get
+        run: sudo apt-get update
+
+      - name: Set up Git repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install Sphinx Read The Docs
+        run: pip install sphinx
+
+      - name: Install Read the Docs theme for Sphinx
+        run: pip install sphinx-rtd-theme
+
+      - name: Build website
+        working-directory: doc
+        run: make html
+
+      - name: Upload website
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: doc/build/html
+          retention-days: ${{ github.event.repository.private && 1 || 7 }}
+
+  check-pages-status:
+    name: Check whether GitHub Pages is enabled
+    runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.check-pages.outputs.enabled }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Check if GitHub Pages is enabled
+        id: check-pages
+        run: bash .github/scripts/check-pages-enabled.sh
+
+  deploy-website:
+    name: Deploy to GitHub Pages
+    needs: [build-website, check-pages-status]
+    if: >
+      needs.check-pages-status.outputs.enabled == 'true' &&
+      github.event_name != 'pull_request'
+    permissions:
+      pages: write
+      id-token: write
+    concurrency:
+      group: "pages"
+      cancel-in-progress: false
+    
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Set up GitHub Pages
+        uses: actions/configure-pages@v5
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This pull requests consists of 3 commits that add GitHub Actions workflows.
1. The first commit initialises the main `.github/workflows/runner.yaml` workflow that will orchestrate all other workflows.
  Moreover, it adds a workflow that builds the Neper documentation in `doc/` and, if configured, deploys it to a GitHub Pages website.
  (I understand that the deployment logic is currently in the `gh-pages` branch whwre the whole website resides, not only documentation. However, I believe that deploying the documentation automatically via GitHub Actions is a step forward.)
  For this the workflow file `.github/workflows/website.yaml` is created (together with the helper scrtipt `.github/scripts/check-pages-enabled.sh`), and called by `.github/workflows/runner.yaml`.
2. The second commit adds a build workflow for `Ubuntu Linux` on `arm64` and `x86_64` architectures in the file `.github/workflows/linux.yaml`, called in `.github/workflows/runner.yaml`.
  Currently the configuration is minimal (without any optional runtime dependencies) which makes some tests fail.
  Failed tests are ignored in order to finish the workflow and upload the final executable.
  I am not sure whether the final executable can be freely run, but at this stage this workflow is an initial step towards a full GitHub Actions automation.
3. The second commit adds a build workflow for `MacOS` on `arm64` and `x86_64` architectures in the file `.github/workflows/macos.yaml`, called in `.github/workflows/runner.yaml`.
  Everything said in the previous point applies here as well.