### PR TITLE
Add GitHub Actions permissions to the caller workflow

### DIFF
--- a/.github/workflows/runner.yaml
+++ b/.github/workflows/runner.yaml
@@ -9,6 +9,10 @@ on:
     branches:
       - main
 
+permissions:
+  pages: write
+  id-token: write
+
 jobs:
   website:
     name: Website


### PR DESCRIPTION
This was suggested by ChatGPT to fix the error in [https://github.com/neperfepx/neper/actions/runs/25063548781](https://github.com/neperfepx/neper/actions/runs/25063548781) for commit [https://github.com/neperfepx/neper/commit/7f1a8ef945ab79d8d0d52b9c7750d7234156f7c5](https://github.com/neperfepx/neper/commit/7f1a8ef945ab79d8d0d52b9c7750d7234156f7c5) (the workflow didn't even start running).
On my first local pull request there were no issues: [https://github.com/kipiberbatov/neper/actions/runs/20378595841](https://github.com/kipiberbatov/neper/actions/runs/20378595841).
Running the workflow for the same commit [https://github.com/neperfepx/neper/commit/7f1a8ef945ab79d8d0d52b9c7750d7234156f7c5](https://github.com/neperfepx/neper/commit/7f1a8ef945ab79d8d0d52b9c7750d7234156f7c5) on my fork started successfully, although there is a new error related to Sphinx: [https://github.com/kipiberbatov/neper/actions/runs/25073728831](https://github.com/kipiberbatov/neper/actions/runs/25073728831).
This pull request was first tested on my fork and the workflow was run, but with the same Sphinx error: [https://github.com/kipiberbatov/neper/actions/runs/25074988152](https://github.com/kipiberbatov/neper/actions/runs/25074988152).
I hope it will run in the upstream as well.
