### PR TITLE
Roll back to older versions of Sphinx

### DIFF
--- a/.github/workflows/runner.yaml
+++ b/.github/workflows/runner.yaml
@@ -9,6 +9,10 @@ on:
     branches:
       - main
 
+permissions:
+  pages: write
+  id-token: write
+
 jobs:
   website:
     name: Website

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -22,8 +22,8 @@ jobs:
       - name: Install pip
         run: python -m pip install --upgrade pip
 
-      - name: Install Sphinx Read The Docs
-        run: pip install sphinx
+      - name: Install Sphinx
+        run: pip install "sphinx<8"
 
       - name: Install Read the Docs theme for Sphinx
         run: pip install sphinx-rtd-theme


### PR DESCRIPTION
Fix the Sphinx 9.1.0 error in [https://github.com/neperfepx/neper/actions/runs/25075778039](https://github.com/neperfepx/neper/actions/runs/25075778039) by rolling back to versions prior to Sphinx 8.