### PR TITLE
Update versions of official GitHub Actions

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -43,7 +43,7 @@ jobs:
         run: ctest
 
       - name: Upload Neper executable
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: neper-linux-${{ matrix.arch }}
           path: src/build/neper

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -55,7 +55,7 @@ jobs:
         run: ctest
 
       - name: Upload Neper executable
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: neper-macos-${{ matrix.arch }}
           path: src/build/neper

--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -33,7 +33,7 @@ jobs:
         run: make html
 
       - name: Upload website
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: doc/build/html
           retention-days: ${{ github.event.repository.private && 1 || 7 }}
@@ -70,8 +70,8 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Set up GitHub Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
Update ofiicial actions so that GitHub will not warn us that Node.js 20 will be deprecated in favour of Node.js 24.