### PR TITLE
Trust system Homebrew taps

### DIFF
--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -20,6 +20,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Trust system Homebrew taps
+        run: brew trust aws/tap azure/bicep
+
       - name: Install GNU Scientific Library
         run: brew install gsl
 


### PR DESCRIPTION
Make sure that the following warning disappears:
```
Warning: The following taps are not trusted:
  aws/tap
  azure/bicep

Homebrew will ignore formulae, casks and commands from these taps when `HOMEBREW_REQUIRE_TAP_TRUST` is set.
This will become the default in Homebrew 6.0.0 or 5.2.0, whichever comes first.
Enable trust checks now with:
  export HOMEBREW_REQUIRE_TAP_TRUST=1
Trust specific formulae, casks or commands with:
  brew trust --formula <user>/<tap>/<formula>
  brew trust --cask <user>/<tap>/<cask>
  brew trust --command <user>/<tap>/<command>
or trust installed formulae from these taps with:
  brew trust --formula azure/bicep/bicep
You can trust all formulae, casks and commands from these taps with:
  brew trust aws/tap azure/bicep
Prefer trusting only the specific formulae, casks or commands you need.
Untap them with:
  brew untap aws/tap azure/bicep
To keep allowing them by default during the transition:
  export HOMEBREW_NO_REQUIRE_TAP_TRUST=1
This is not recommended and will be removed in a later release.

Inspect the formula dependency plan before installing with `brew install --ask`.
Enable ask mode by setting `HOMEBREW_ASK=1`.
Hide these hints with `HOMEBREW_NO_ENV_HINTS=1` (see `man brew`).
```